### PR TITLE
Don't add includes that have ".." in their path name

### DIFF
--- a/generator/mavparse.py
+++ b/generator/mavparse.py
@@ -314,7 +314,9 @@ class MAVXML(object):
             elif in_element == "mavlink.version":
                 self.version = int(data)
             elif in_element == "mavlink.include":
-                self.include.append(data)
+                # Don't add includes which are elsewhere in the folder structure
+                if  ".." not in data:
+                    self.include.append(data)
 
         f = open(filename, mode='rb')
         p = xml.parsers.expat.ParserCreate()


### PR DESCRIPTION
As the recent changes to storm32.xml in Mavlink seems to have screwed up pymavlink, the idea of this change is simply to ignore any xml includes that have ".." in their path for now, until Mavlink or Pymavlink sorts this issue out.